### PR TITLE
[1.5] Implement N-body gravity force calculation with softening

### DIFF
--- a/Scripts/Physics/BodyRegistry.cs
+++ b/Scripts/Physics/BodyRegistry.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+public class BodyRegistry
+{
+    private readonly Dictionary<string, CelestialBodyData> _bodies = new();
+
+    public int Count => _bodies.Count;
+
+    public void Add(CelestialBodyData body)
+    {
+        _bodies[body.Id] = body;
+    }
+
+    public bool Remove(string id)
+    {
+        return _bodies.Remove(id);
+    }
+
+    public CelestialBodyData GetById(string id)
+    {
+        return _bodies.TryGetValue(id, out var body) ? body : null;
+    }
+
+    public IReadOnlyCollection<CelestialBodyData> GetAll()
+    {
+        return _bodies.Values;
+    }
+
+    public void Clear()
+    {
+        _bodies.Clear();
+    }
+}

--- a/Scripts/Physics/GravityCalculator.cs
+++ b/Scripts/Physics/GravityCalculator.cs
@@ -1,0 +1,37 @@
+using Godot;
+using System.Collections.Generic;
+using System.Linq;
+
+public class GravityCalculator
+{
+    public void CalculateForces(IReadOnlyCollection<CelestialBodyData> bodies, float g, float softening)
+    {
+        var bodyList = bodies.ToList();
+
+        foreach (var body in bodyList)
+        {
+            body.ResetForce();
+        }
+
+        for (int i = 0; i < bodyList.Count; i++)
+        {
+            for (int j = i + 1; j < bodyList.Count; j++)
+            {
+                var bodyA = bodyList[i];
+                var bodyB = bodyList[j];
+
+                Vector2 direction = bodyB.Position - bodyA.Position;
+                float distanceSq = direction.LengthSquared();
+                float softenedDistSq = distanceSq + softening * softening;
+
+                float forceMagnitude = g * bodyA.Mass * bodyB.Mass / softenedDistSq;
+
+                Vector2 forceDirection = direction.Normalized();
+                Vector2 force = forceDirection * forceMagnitude;
+
+                bodyA.ApplyForce(force);
+                bodyB.ApplyForce(-force);  // Newton's 3rd law
+            }
+        }
+    }
+}

--- a/test/unit/BodyRegistryTest.cs
+++ b/test/unit/BodyRegistryTest.cs
@@ -1,0 +1,101 @@
+using GdUnit4;
+using Godot;
+using static GdUnit4.Assertions;
+
+namespace GravityStellar.Tests.Physics;
+
+[TestSuite]
+public class BodyRegistryTest
+{
+    private BodyRegistry _registry;
+
+    [BeforeTest]
+    public void Setup()
+    {
+        _registry = new BodyRegistry();
+    }
+
+    [TestCase]
+    public void ShouldStartEmpty()
+    {
+        AssertThat(_registry.Count).IsEqual(0);
+    }
+
+    [TestCase]
+    public void ShouldAddBody()
+    {
+        var body = new CelestialBodyData("planet-1", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        _registry.Add(body);
+        AssertThat(_registry.Count).IsEqual(1);
+    }
+
+    [TestCase]
+    public void ShouldRetrieveBodyById()
+    {
+        var body = new CelestialBodyData("planet-1", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        _registry.Add(body);
+
+        var retrieved = _registry.GetById("planet-1");
+        AssertThat(retrieved).IsNotNull();
+        AssertThat(retrieved.Id).IsEqual("planet-1");
+    }
+
+    [TestCase]
+    public void ShouldReturnNullForUnknownId()
+    {
+        var result = _registry.GetById("nonexistent");
+        AssertThat(result).IsNull();
+    }
+
+    [TestCase]
+    public void ShouldRemoveBody()
+    {
+        var body = new CelestialBodyData("planet-1", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        _registry.Add(body);
+
+        var removed = _registry.Remove("planet-1");
+        AssertThat(removed).IsTrue();
+        AssertThat(_registry.Count).IsEqual(0);
+    }
+
+    [TestCase]
+    public void ShouldReturnFalseWhenRemovingUnknownId()
+    {
+        var removed = _registry.Remove("nonexistent");
+        AssertThat(removed).IsFalse();
+    }
+
+    [TestCase]
+    public void ShouldGetAllBodies()
+    {
+        var body1 = new CelestialBodyData("planet-1", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        var body2 = new CelestialBodyData("planet-2", 20f, 2f, Vector2.One, Vector2.Zero);
+        _registry.Add(body1);
+        _registry.Add(body2);
+
+        var all = _registry.GetAll();
+        AssertThat(all.Count).IsEqual(2);
+    }
+
+    [TestCase]
+    public void ShouldOverwriteExistingBodyWithSameId()
+    {
+        var body1 = new CelestialBodyData("planet-1", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        var body2 = new CelestialBodyData("planet-1", 50f, 5f, Vector2.One, Vector2.Zero);
+        _registry.Add(body1);
+        _registry.Add(body2);
+
+        AssertThat(_registry.Count).IsEqual(1);
+        AssertThat(_registry.GetById("planet-1").Mass).IsEqual(50f);
+    }
+
+    [TestCase]
+    public void ShouldClearAllBodies()
+    {
+        _registry.Add(new CelestialBodyData("planet-1", 10f, 1f, Vector2.Zero, Vector2.Zero));
+        _registry.Add(new CelestialBodyData("planet-2", 20f, 2f, Vector2.One, Vector2.Zero));
+        _registry.Clear();
+
+        AssertThat(_registry.Count).IsEqual(0);
+    }
+}

--- a/test/unit/GravityCalculatorTest.cs
+++ b/test/unit/GravityCalculatorTest.cs
@@ -1,0 +1,97 @@
+using GdUnit4;
+using Godot;
+using System.Collections.Generic;
+using static GdUnit4.Assertions;
+
+namespace GravityStellar.Tests.Physics;
+
+[TestSuite]
+public class GravityCalculatorTest
+{
+    private GravityCalculator _calculator;
+
+    [BeforeTest]
+    public void Setup()
+    {
+        _calculator = new GravityCalculator();
+    }
+
+    [TestCase]
+    public void ShouldHandleEmptyAndSingleBody()
+    {
+        _calculator.CalculateForces(new List<CelestialBodyData>(), 1f, 0.1f);
+
+        var bodies = new List<CelestialBodyData>
+        {
+            new("body-1", 10f, 1f, Vector2.Zero, Vector2.Zero)
+        };
+        _calculator.CalculateForces(bodies, 1f, 0.1f);
+        AssertThat(bodies[0].AccumulatedForce).IsEqual(Vector2.Zero);
+    }
+
+    [TestCase]
+    public void ShouldApplyEqualAndOppositeForces()
+    {
+        var bodyA = new CelestialBodyData("a", 10f, 1f, new Vector2(0, 0), Vector2.Zero);
+        var bodyB = new CelestialBodyData("b", 10f, 1f, new Vector2(10, 0), Vector2.Zero);
+        _calculator.CalculateForces(new List<CelestialBodyData> { bodyA, bodyB }, 1f, 0f);
+
+        AssertThat(bodyA.AccumulatedForce.X).IsGreater(0f);
+        AssertThat(bodyB.AccumulatedForce.X).IsLess(0f);
+        AssertThat(bodyA.AccumulatedForce.Length())
+            .IsEqualApprox(bodyB.AccumulatedForce.Length(), 0.001f);
+    }
+
+    [TestCase]
+    public void ShouldScaleForceWithMass()
+    {
+        var a1 = new CelestialBodyData("a", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        var b1 = new CelestialBodyData("b", 10f, 1f, new Vector2(10, 0), Vector2.Zero);
+        _calculator.CalculateForces(new List<CelestialBodyData> { a1, b1 }, 1f, 0f);
+
+        var a2 = new CelestialBodyData("c", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        var b2 = new CelestialBodyData("d", 20f, 1f, new Vector2(10, 0), Vector2.Zero);
+        _calculator.CalculateForces(new List<CelestialBodyData> { a2, b2 }, 1f, 0f);
+
+        AssertThat(a2.AccumulatedForce.Length()).IsEqualApprox(a1.AccumulatedForce.Length() * 2f, 0.001f);
+    }
+
+    [TestCase]
+    public void ShouldReduceForceWithDistance()
+    {
+        var near1 = new CelestialBodyData("a", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        var near2 = new CelestialBodyData("b", 10f, 1f, new Vector2(5, 0), Vector2.Zero);
+        _calculator.CalculateForces(new List<CelestialBodyData> { near1, near2 }, 1f, 0f);
+
+        var far1 = new CelestialBodyData("c", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        var far2 = new CelestialBodyData("d", 10f, 1f, new Vector2(10, 0), Vector2.Zero);
+        _calculator.CalculateForces(new List<CelestialBodyData> { far1, far2 }, 1f, 0f);
+
+        AssertThat(near1.AccumulatedForce.Length()).IsGreater(far1.AccumulatedForce.Length());
+    }
+
+    [TestCase]
+    public void ShouldApplySoftening()
+    {
+        var a1 = new CelestialBodyData("a", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        var b1 = new CelestialBodyData("b", 10f, 1f, new Vector2(1, 0), Vector2.Zero);
+        _calculator.CalculateForces(new List<CelestialBodyData> { a1, b1 }, 1f, 0f);
+
+        var a2 = new CelestialBodyData("c", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        var b2 = new CelestialBodyData("d", 10f, 1f, new Vector2(1, 0), Vector2.Zero);
+        _calculator.CalculateForces(new List<CelestialBodyData> { a2, b2 }, 1f, 5f);
+
+        AssertThat(a2.AccumulatedForce.Length()).IsLess(a1.AccumulatedForce.Length());
+    }
+
+    [TestCase]
+    public void ShouldResetForcesBeforeCalculation()
+    {
+        var bodyA = new CelestialBodyData("a", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        var bodyB = new CelestialBodyData("b", 10f, 1f, new Vector2(10, 0), Vector2.Zero);
+        bodyA.ApplyForce(new Vector2(999, 999));
+
+        _calculator.CalculateForces(new List<CelestialBodyData> { bodyA, bodyB }, 1f, 0f);
+        AssertThat(bodyA.AccumulatedForce.X).IsLess(999f);
+    }
+}


### PR DESCRIPTION
Stateless GravityCalculator implementing F = G*m1*m2 / (r² + ε²) with Newton's 3rd law. O(N²) pairwise, softening prevents singularities.

Closes #64
Part of Epic #26