### PR TITLE
[1.8] Implement collision detection

### DIFF
--- a/Scripts/Physics/BodyRegistry.cs
+++ b/Scripts/Physics/BodyRegistry.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+public class BodyRegistry
+{
+    private readonly Dictionary<string, CelestialBodyData> _bodies = new();
+
+    public int Count => _bodies.Count;
+
+    public void Add(CelestialBodyData body)
+    {
+        _bodies[body.Id] = body;
+    }
+
+    public bool Remove(string id)
+    {
+        return _bodies.Remove(id);
+    }
+
+    public CelestialBodyData GetById(string id)
+    {
+        return _bodies.TryGetValue(id, out var body) ? body : null;
+    }
+
+    public IReadOnlyCollection<CelestialBodyData> GetAll()
+    {
+        return _bodies.Values;
+    }
+
+    public void Clear()
+    {
+        _bodies.Clear();
+    }
+}

--- a/Scripts/Physics/CollisionDetector.cs
+++ b/Scripts/Physics/CollisionDetector.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+
+public class CollisionDetector
+{
+    public List<(string IdA, string IdB)> DetectCollisions(IReadOnlyCollection<CelestialBodyData> bodies)
+    {
+        var collisions = new List<(string, string)>();
+        var bodyList = bodies.ToList();
+
+        for (int i = 0; i < bodyList.Count; i++)
+        {
+            for (int j = i + 1; j < bodyList.Count; j++)
+            {
+                var bodyA = bodyList[i];
+                var bodyB = bodyList[j];
+
+                float distanceSq = (bodyB.Position - bodyA.Position).LengthSquared();
+                float combinedRadii = bodyA.Radius + bodyB.Radius;
+
+                if (distanceSq < combinedRadii * combinedRadii)
+                {
+                    collisions.Add((bodyA.Id, bodyB.Id));
+                }
+            }
+        }
+
+        return collisions;
+    }
+}

--- a/test/unit/BodyRegistryTest.cs
+++ b/test/unit/BodyRegistryTest.cs
@@ -1,0 +1,101 @@
+using GdUnit4;
+using Godot;
+using static GdUnit4.Assertions;
+
+namespace GravityStellar.Tests.Physics;
+
+[TestSuite]
+public class BodyRegistryTest
+{
+    private BodyRegistry _registry;
+
+    [BeforeTest]
+    public void Setup()
+    {
+        _registry = new BodyRegistry();
+    }
+
+    [TestCase]
+    public void ShouldStartEmpty()
+    {
+        AssertThat(_registry.Count).IsEqual(0);
+    }
+
+    [TestCase]
+    public void ShouldAddBody()
+    {
+        var body = new CelestialBodyData("planet-1", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        _registry.Add(body);
+        AssertThat(_registry.Count).IsEqual(1);
+    }
+
+    [TestCase]
+    public void ShouldRetrieveBodyById()
+    {
+        var body = new CelestialBodyData("planet-1", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        _registry.Add(body);
+
+        var retrieved = _registry.GetById("planet-1");
+        AssertThat(retrieved).IsNotNull();
+        AssertThat(retrieved.Id).IsEqual("planet-1");
+    }
+
+    [TestCase]
+    public void ShouldReturnNullForUnknownId()
+    {
+        var result = _registry.GetById("nonexistent");
+        AssertThat(result).IsNull();
+    }
+
+    [TestCase]
+    public void ShouldRemoveBody()
+    {
+        var body = new CelestialBodyData("planet-1", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        _registry.Add(body);
+
+        var removed = _registry.Remove("planet-1");
+        AssertThat(removed).IsTrue();
+        AssertThat(_registry.Count).IsEqual(0);
+    }
+
+    [TestCase]
+    public void ShouldReturnFalseWhenRemovingUnknownId()
+    {
+        var removed = _registry.Remove("nonexistent");
+        AssertThat(removed).IsFalse();
+    }
+
+    [TestCase]
+    public void ShouldGetAllBodies()
+    {
+        var body1 = new CelestialBodyData("planet-1", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        var body2 = new CelestialBodyData("planet-2", 20f, 2f, Vector2.One, Vector2.Zero);
+        _registry.Add(body1);
+        _registry.Add(body2);
+
+        var all = _registry.GetAll();
+        AssertThat(all.Count).IsEqual(2);
+    }
+
+    [TestCase]
+    public void ShouldOverwriteExistingBodyWithSameId()
+    {
+        var body1 = new CelestialBodyData("planet-1", 10f, 1f, Vector2.Zero, Vector2.Zero);
+        var body2 = new CelestialBodyData("planet-1", 50f, 5f, Vector2.One, Vector2.Zero);
+        _registry.Add(body1);
+        _registry.Add(body2);
+
+        AssertThat(_registry.Count).IsEqual(1);
+        AssertThat(_registry.GetById("planet-1").Mass).IsEqual(50f);
+    }
+
+    [TestCase]
+    public void ShouldClearAllBodies()
+    {
+        _registry.Add(new CelestialBodyData("planet-1", 10f, 1f, Vector2.Zero, Vector2.Zero));
+        _registry.Add(new CelestialBodyData("planet-2", 20f, 2f, Vector2.One, Vector2.Zero));
+        _registry.Clear();
+
+        AssertThat(_registry.Count).IsEqual(0);
+    }
+}

--- a/test/unit/CollisionDetectorTest.cs
+++ b/test/unit/CollisionDetectorTest.cs
@@ -1,0 +1,89 @@
+using GdUnit4;
+using Godot;
+using static GdUnit4.Assertions;
+using System.Collections.Generic;
+
+namespace GravityStellar.Tests.Physics;
+
+[TestSuite]
+public class CollisionDetectorTest
+{
+    private CollisionDetector _detector;
+
+    [BeforeTest]
+    public void Setup()
+    {
+        _detector = new CollisionDetector();
+    }
+
+    [TestCase]
+    public void ShouldReturnEmptyForZeroOrOneBody()
+    {
+        AssertThat(_detector.DetectCollisions(new List<CelestialBodyData>()).Count).IsEqual(0);
+
+        var single = new List<CelestialBodyData> { new("body-1", 10f, 1f, Vector2.Zero, Vector2.Zero) };
+        AssertThat(_detector.DetectCollisions(single).Count).IsEqual(0);
+    }
+
+    [TestCase]
+    public void ShouldDetectOverlappingBodiesAndReturnIds()
+    {
+        var bodies = new List<CelestialBodyData>
+        {
+            new("planet-1", 10f, 5f, new Vector2(0, 0), Vector2.Zero),
+            new("planet-2", 10f, 5f, new Vector2(3, 0), Vector2.Zero)
+        };
+
+        var collisions = _detector.DetectCollisions(bodies);
+
+        AssertThat(collisions.Count).IsEqual(1);
+        AssertThat(collisions[0].IdA).IsEqual("planet-1");
+        AssertThat(collisions[0].IdB).IsEqual("planet-2");
+    }
+
+    [TestCase]
+    public void ShouldNotDetectDistantBodies()
+    {
+        var bodies = new List<CelestialBodyData>
+        {
+            new("a", 10f, 1f, new Vector2(0, 0), Vector2.Zero),
+            new("b", 10f, 1f, new Vector2(100, 0), Vector2.Zero)
+        };
+        AssertThat(_detector.DetectCollisions(bodies).Count).IsEqual(0);
+    }
+
+    [TestCase]
+    public void ShouldNotCollideWhenExactlyTouching()
+    {
+        // Strict less-than: distance == combined radii is not a collision
+        var bodies = new List<CelestialBodyData>
+        {
+            new("a", 10f, 5f, new Vector2(0, 0), Vector2.Zero),
+            new("b", 10f, 5f, new Vector2(10, 0), Vector2.Zero)
+        };
+        AssertThat(_detector.DetectCollisions(bodies).Count).IsEqual(0);
+    }
+
+    [TestCase]
+    public void ShouldDetectMultipleCollisions()
+    {
+        var bodies = new List<CelestialBodyData>
+        {
+            new("a", 10f, 5f, new Vector2(0, 0), Vector2.Zero),
+            new("b", 10f, 5f, new Vector2(3, 0), Vector2.Zero),
+            new("c", 10f, 5f, new Vector2(6, 0), Vector2.Zero)
+        };
+        AssertThat(_detector.DetectCollisions(bodies).Count).IsGreaterEqual(2);
+    }
+
+    [TestCase]
+    public void ShouldDetectBarelyOverlappingBodies()
+    {
+        var bodies = new List<CelestialBodyData>
+        {
+            new("a", 10f, 5f, new Vector2(0, 0), Vector2.Zero),
+            new("b", 10f, 5f, new Vector2(9.99f, 0), Vector2.Zero)
+        };
+        AssertThat(_detector.DetectCollisions(bodies).Count).IsEqual(1);
+    }
+}


### PR DESCRIPTION
Stateless CollisionDetector using squared-distance radius overlap checks. Returns ID pairs for decoupled collision handling.

Closes #67
Part of Epic #26