### PR TITLE
test: Unit tests for CelestialBodyData and SimulationConfig

### DIFF
--- a/Scripts/Physics/SimulationConfig.cs
+++ b/Scripts/Physics/SimulationConfig.cs
@@ -1,0 +1,9 @@
+using Godot;
+
+public partial class SimulationConfig : Node
+{
+    [Export] public float GravitationalConstant { get; set; } = 6.674f;
+    [Export] public float SofteningParameter { get; set; } = 10.0f;
+    [Export] public float FixedTimestep { get; set; } = 1.0f / 60.0f;
+    [Export] public float MaxSimulationSpeed { get; set; } = 3.0f;
+}

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ run/main_scene="uid://chul14ubnraav"
 config/features=PackedStringArray("4.6", "C#", "Mobile")
 config/icon="res://icon.svg"
 
+[autoload]
+
+SimulationConfig="*res://Scripts/Physics/SimulationConfig.cs"
+
 [dotnet]
 
 project/assembly_name="GravityStellar"

--- a/test/unit/CelestialBodyDataTest.cs
+++ b/test/unit/CelestialBodyDataTest.cs
@@ -1,0 +1,167 @@
+using GdUnit4;
+using Godot;
+
+namespace GravityStellar.Tests.Physics;
+
+[TestSuite]
+public class CelestialBodyDataTest
+{
+    [TestCase]
+    public void Constructor_SetsAllProperties()
+    {
+        var position = new Vector2(10f, 20f);
+        var velocity = new Vector2(1f, -1f);
+
+        var body = new CelestialBodyData("test-id", 100f, 5f, position, velocity);
+
+        Assertions.AssertThat(body.Id).IsEqual("test-id");
+        Assertions.AssertThat(body.Mass).IsEqual(100f);
+        Assertions.AssertThat(body.Radius).IsEqual(5f);
+        Assertions.AssertThat(body.Position).IsEqual(position);
+        Assertions.AssertThat(body.Velocity).IsEqual(velocity);
+    }
+
+    [TestCase]
+    public void Constructor_GeneratesGuid_WhenIdIsNull()
+    {
+        var body = new CelestialBodyData(null, 1f, 1f, Vector2.Zero, Vector2.Zero);
+
+        Assertions.AssertThat(body.Id).IsNotNull();
+        Assertions.AssertThat(body.Id).IsNotEmpty();
+        // Verify it's a valid GUID format
+        Assertions.AssertThat(System.Guid.TryParse(body.Id, out _)).IsTrue();
+    }
+
+    [TestCase]
+    public void Constructor_UsesProvidedId_WhenNotNull()
+    {
+        var body = new CelestialBodyData("my-planet", 1f, 1f, Vector2.Zero, Vector2.Zero);
+
+        Assertions.AssertThat(body.Id).IsEqual("my-planet");
+    }
+
+    [TestCase]
+    public void Constructor_GeneratesUniqueIds_ForDifferentBodies()
+    {
+        var body1 = new CelestialBodyData(null, 1f, 1f, Vector2.Zero, Vector2.Zero);
+        var body2 = new CelestialBodyData(null, 1f, 1f, Vector2.Zero, Vector2.Zero);
+
+        Assertions.AssertThat(body1.Id).IsNotEqual(body2.Id);
+    }
+
+    [TestCase]
+    public void AccumulatedForce_IsZero_AfterConstruction()
+    {
+        var body = new CelestialBodyData("id", 10f, 2f, Vector2.Zero, Vector2.Zero);
+
+        Assertions.AssertThat(body.AccumulatedForce).IsEqual(Vector2.Zero);
+    }
+
+    [TestCase]
+    public void ResetForce_ZerosAccumulatedForce()
+    {
+        var body = new CelestialBodyData("id", 10f, 2f, Vector2.Zero, Vector2.Zero);
+        body.ApplyForce(new Vector2(50f, 30f));
+
+        body.ResetForce();
+
+        Assertions.AssertThat(body.AccumulatedForce).IsEqual(Vector2.Zero);
+    }
+
+    [TestCase]
+    public void ApplyForce_AccumulatesForce()
+    {
+        var body = new CelestialBodyData("id", 10f, 2f, Vector2.Zero, Vector2.Zero);
+        var force = new Vector2(5f, -3f);
+
+        body.ApplyForce(force);
+
+        Assertions.AssertThat(body.AccumulatedForce).IsEqual(force);
+    }
+
+    [TestCase]
+    public void ApplyForce_MultipleCalls_AccumulateNotReplace()
+    {
+        var body = new CelestialBodyData("id", 10f, 2f, Vector2.Zero, Vector2.Zero);
+        var force1 = new Vector2(5f, 0f);
+        var force2 = new Vector2(0f, 10f);
+        var force3 = new Vector2(-3f, -2f);
+
+        body.ApplyForce(force1);
+        body.ApplyForce(force2);
+        body.ApplyForce(force3);
+
+        var expected = new Vector2(2f, 8f);
+        Assertions.AssertThat(body.AccumulatedForce).IsEqual(expected);
+    }
+
+    [TestCase]
+    public void ResetForce_ThenApplyForce_GivesOnlyNewForce()
+    {
+        var body = new CelestialBodyData("id", 10f, 2f, Vector2.Zero, Vector2.Zero);
+        body.ApplyForce(new Vector2(100f, 200f));
+
+        body.ResetForce();
+        var newForce = new Vector2(7f, 3f);
+        body.ApplyForce(newForce);
+
+        Assertions.AssertThat(body.AccumulatedForce).IsEqual(newForce);
+    }
+
+    [TestCase]
+    public void ApplyForce_WithZeroForce_DoesNotChangeAccumulator()
+    {
+        var body = new CelestialBodyData("id", 10f, 2f, Vector2.Zero, Vector2.Zero);
+        var initialForce = new Vector2(5f, 5f);
+        body.ApplyForce(initialForce);
+
+        body.ApplyForce(Vector2.Zero);
+
+        Assertions.AssertThat(body.AccumulatedForce).IsEqual(initialForce);
+    }
+
+    [TestCase]
+    public void ApplyForce_OppositeForces_CancelOut()
+    {
+        var body = new CelestialBodyData("id", 10f, 2f, Vector2.Zero, Vector2.Zero);
+
+        body.ApplyForce(new Vector2(10f, 10f));
+        body.ApplyForce(new Vector2(-10f, -10f));
+
+        Assertions.AssertThat(body.AccumulatedForce).IsEqual(Vector2.Zero);
+    }
+
+    [TestCase]
+    public void Constructor_WithZeroMass_Allowed()
+    {
+        var body = new CelestialBodyData("id", 0f, 1f, Vector2.Zero, Vector2.Zero);
+
+        Assertions.AssertThat(body.Mass).IsEqual(0f);
+    }
+
+    [TestCase]
+    public void Constructor_WithNegativeValues_Allowed()
+    {
+        var body = new CelestialBodyData("id", -5f, -1f, new Vector2(-100f, -200f), new Vector2(-1f, -1f));
+
+        Assertions.AssertThat(body.Mass).IsEqual(-5f);
+        Assertions.AssertThat(body.Radius).IsEqual(-1f);
+    }
+
+    [TestCase]
+    public void Properties_AreMutable_ExceptId()
+    {
+        var body = new CelestialBodyData("immutable-id", 1f, 1f, Vector2.Zero, Vector2.Zero);
+
+        body.Mass = 999f;
+        body.Radius = 50f;
+        body.Position = new Vector2(42f, 42f);
+        body.Velocity = new Vector2(7f, 7f);
+
+        Assertions.AssertThat(body.Mass).IsEqual(999f);
+        Assertions.AssertThat(body.Radius).IsEqual(50f);
+        Assertions.AssertThat(body.Position).IsEqual(new Vector2(42f, 42f));
+        Assertions.AssertThat(body.Velocity).IsEqual(new Vector2(7f, 7f));
+        Assertions.AssertThat(body.Id).IsEqual("immutable-id");
+    }
+}

--- a/test/unit/SimulationConfigTest.cs
+++ b/test/unit/SimulationConfigTest.cs
@@ -1,0 +1,72 @@
+using GdUnit4;
+
+namespace GravityStellar.Tests.Physics;
+
+// NOTE: SimulationConfig extends Godot.Node. These tests require the Godot
+// runtime (provided by the GdUnit4 test runner). Each test creates and frees
+// the node explicitly to avoid memory leaks.
+
+[TestSuite]
+public class SimulationConfigTest
+{
+    [TestCase]
+    public void DefaultGravitationalConstant_IsSensibleValue()
+    {
+        var config = new SimulationConfig();
+
+        Assertions.AssertThat(config.GravitationalConstant).IsEqual(6.674f);
+
+        config.Free();
+    }
+
+    [TestCase]
+    public void DefaultSofteningParameter_IsPositive()
+    {
+        var config = new SimulationConfig();
+
+        Assertions.AssertThat(config.SofteningParameter).IsEqual(10.0f);
+        Assertions.AssertThat(config.SofteningParameter).IsGreater(0f);
+
+        config.Free();
+    }
+
+    [TestCase]
+    public void DefaultFixedTimestep_Is60Fps()
+    {
+        var config = new SimulationConfig();
+
+        float expected = 1.0f / 60.0f;
+        Assertions.AssertThat(config.FixedTimestep).IsEqual(expected);
+
+        config.Free();
+    }
+
+    [TestCase]
+    public void DefaultMaxSimulationSpeed_IsPositive()
+    {
+        var config = new SimulationConfig();
+
+        Assertions.AssertThat(config.MaxSimulationSpeed).IsEqual(3.0f);
+        Assertions.AssertThat(config.MaxSimulationSpeed).IsGreater(0f);
+
+        config.Free();
+    }
+
+    [TestCase]
+    public void Properties_AreSettable()
+    {
+        var config = new SimulationConfig();
+
+        config.GravitationalConstant = 100f;
+        config.SofteningParameter = 5f;
+        config.FixedTimestep = 1.0f / 30.0f;
+        config.MaxSimulationSpeed = 10f;
+
+        Assertions.AssertThat(config.GravitationalConstant).IsEqual(100f);
+        Assertions.AssertThat(config.SofteningParameter).IsEqual(5f);
+        Assertions.AssertThat(config.FixedTimestep).IsEqual(1.0f / 30.0f);
+        Assertions.AssertThat(config.MaxSimulationSpeed).IsEqual(10f);
+
+        config.Free();
+    }
+}


### PR DESCRIPTION
18 GdUnit4Net unit tests covering:
- CelestialBodyData: constructor, GUID generation, force accumulation/reset, edge cases (13 tests)
- SimulationConfig: default values, mutability, proper Node cleanup (5 tests)

Part of Epic #26