### PR TITLE
[2.2] Create PlanetScene (Node2D + Sprite2D + CollisionShape2D)

### DIFF
--- a/Scenes/PlanetScene.tscn
+++ b/Scenes/PlanetScene.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=4 format=3 uid="uid://dk7r4m2xpw3q1"]
+
+[ext_resource type="Script" path="res://Scripts/Visual/PlanetVisual.cs" id="1"]
+[ext_resource type="Texture2D" path="res://icon.svg" id="2"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_1"]
+radius = 50.0
+
+[node name="PlanetVisual" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource("2")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CircleShape2D_1")

--- a/Scripts/Visual/PlanetVisual.cs
+++ b/Scripts/Visual/PlanetVisual.cs
@@ -1,0 +1,36 @@
+using Godot;
+
+namespace GravityStellar.Visual;
+
+public partial class PlanetVisual : Node2D
+{
+    private Sprite2D _sprite;
+    private CollisionShape2D _collisionShape;
+
+    public Planet BoundPlanet { get; private set; }
+
+    public override void _Ready()
+    {
+        _sprite = GetNode<Sprite2D>("Sprite2D");
+        _collisionShape = GetNode<CollisionShape2D>("CollisionShape2D");
+    }
+
+    public void Bind(Planet planet)
+    {
+        BoundPlanet = planet;
+        UpdateVisuals();
+    }
+
+    public void UpdateVisuals()
+    {
+        if (BoundPlanet == null)
+            return;
+
+        Position = BoundPlanet.Position;
+
+        float scaleFactor = BoundPlanet.Radius / 50.0f;
+        Scale = new Vector2(scaleFactor, scaleFactor);
+
+        Modulate = BoundPlanet.PlanetColor;
+    }
+}

--- a/test/unit/PlanetVisualTest.cs
+++ b/test/unit/PlanetVisualTest.cs
@@ -1,0 +1,83 @@
+using Godot;
+using GdUnit4;
+using GravityStellar.Visual;
+using static GdUnit4.Assertions;
+
+namespace GravityStellar.Tests.Visual;
+
+[TestSuite]
+public class PlanetVisualTest
+{
+    [TestCase]
+    public void ShouldHaveNullBoundPlanetInitially()
+    {
+        var visual = new PlanetVisual();
+        AssertThat(visual.BoundPlanet).IsNull();
+    }
+
+    [TestCase]
+    public void ShouldBindPlanet()
+    {
+        var planet = new Planet("test-1", 100f, 50f, Vector2.Zero, Vector2.Zero);
+        var visual = new PlanetVisual();
+        visual.Bind(planet);
+        AssertThat(visual.BoundPlanet).IsEqual(planet);
+    }
+
+    [TestCase]
+    public void ShouldUpdatePositionFromPlanet()
+    {
+        var expectedPosition = new Vector2(200f, 300f);
+        var planet = new Planet("test-2", 100f, 50f, expectedPosition, Vector2.Zero);
+        var visual = new PlanetVisual();
+        visual.Bind(planet);
+        AssertThat(visual.Position).IsEqual(expectedPosition);
+    }
+
+    [TestCase]
+    public void ShouldUpdateScaleFromRadius()
+    {
+        float radius = 100f;
+        float expectedScale = radius / 50.0f;
+        var planet = new Planet("test-3", 100f, radius, Vector2.Zero, Vector2.Zero);
+        var visual = new PlanetVisual();
+        visual.Bind(planet);
+        AssertThat(visual.Scale).IsEqual(new Vector2(expectedScale, expectedScale));
+    }
+
+    [TestCase]
+    public void ShouldUpdateColorFromPlanetColor()
+    {
+        var expectedColor = Colors.Red;
+        var planet = new Planet("test-4", 100f, 50f, Vector2.Zero, Vector2.Zero,
+            "Red Planet", expectedColor, 1, false);
+        var visual = new PlanetVisual();
+        visual.Bind(planet);
+        AssertThat(visual.Modulate).IsEqual(expectedColor);
+    }
+
+    [TestCase]
+    public void ShouldNotCrashWhenUpdateVisualsCalledWithoutBind()
+    {
+        var visual = new PlanetVisual();
+        visual.UpdateVisuals();
+        AssertThat(visual.BoundPlanet).IsNull();
+    }
+
+    [TestCase]
+    public void ShouldUpdateVisualsAfterPlanetDataChanges()
+    {
+        var planet = new Planet("test-5", 100f, 50f, Vector2.Zero, Vector2.Zero);
+        var visual = new PlanetVisual();
+        visual.Bind(planet);
+
+        var newPosition = new Vector2(500f, 600f);
+        planet.Position = newPosition;
+        planet.Radius = 200f;
+        visual.UpdateVisuals();
+
+        AssertThat(visual.Position).IsEqual(newPosition);
+        float expectedScale = 200f / 50.0f;
+        AssertThat(visual.Scale).IsEqual(new Vector2(expectedScale, expectedScale));
+    }
+}


### PR DESCRIPTION
Creates the reusable PlanetScene and PlanetVisual script for visual representation of planets.

## Changes
- **Scenes/PlanetScene.tscn** - Node2D root (PlanetVisual) with Sprite2D (icon.svg placeholder) and CollisionShape2D (CircleShape2D, radius 50)
- **Scripts/Visual/PlanetVisual.cs** - Bind(Planet) connects visual to data, UpdateVisuals() syncs position/scale/color. No _Process - syncing handled externally.
- **test/unit/PlanetVisualTest.cs** - 7 unit tests covering bind, position/scale/color sync, null safety, and re-sync after data changes.

Closes #69

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>