### PR TITLE
[2.4] Add basic particle trail to PlanetScene

### DIFF
--- a/Scenes/PlanetScene.tscn
+++ b/Scenes/PlanetScene.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://dk7r4m2xpw3q1"]
+[gd_scene load_steps=5 format=3 uid="uid://dk7r4m2xpw3q1"]
 
 [ext_resource type="Script" path="res://Scripts/Visual/PlanetVisual.cs" id="1"]
 [ext_resource type="Texture2D" path="res://icon.svg" id="2"]
+[ext_resource type="Script" path="res://Scripts/Visual/OrbitTrail.cs" id="3"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_1"]
 radius = 50.0
@@ -14,3 +15,6 @@ texture = ExtResource("2")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_1")
+
+[node name="OrbitTrail" type="Line2D" parent="."]
+script = ExtResource("3")

--- a/Scripts/Visual/OrbitTrail.cs
+++ b/Scripts/Visual/OrbitTrail.cs
@@ -1,0 +1,42 @@
+using Godot;
+
+namespace GravityStellar.Visual;
+
+public partial class OrbitTrail : Line2D
+{
+    [Export] public int MaxPoints { get; set; } = 100;
+    [Export] public float MinDistance { get; set; } = 2.0f;
+
+    private Vector2 _lastRecordedPosition;
+
+    public override void _Ready()
+    {
+        Width = 2.0f;
+        DefaultColor = new Color(1, 1, 1, 0.5f);
+        TopLevel = true;
+
+        var gradient = new Gradient();
+        gradient.SetColor(0, new Color(1, 1, 1, 0.0f));
+        gradient.SetColor(1, new Color(1, 1, 1, 0.7f));
+        Gradient = gradient;
+    }
+
+    public void RecordPosition(Vector2 globalPos)
+    {
+        if (GetPointCount() > 0 && globalPos.DistanceTo(_lastRecordedPosition) < MinDistance)
+            return;
+
+        AddPoint(globalPos);
+        _lastRecordedPosition = globalPos;
+
+        while (GetPointCount() > MaxPoints)
+        {
+            RemovePoint(0);
+        }
+    }
+
+    public void ClearTrail()
+    {
+        ClearPoints();
+    }
+}

--- a/Scripts/Visual/PlanetVisual.cs
+++ b/Scripts/Visual/PlanetVisual.cs
@@ -6,6 +6,7 @@ public partial class PlanetVisual : Node2D
 {
     private Sprite2D _sprite;
     private CollisionShape2D _collisionShape;
+    private OrbitTrail _orbitTrail;
 
     public Planet BoundPlanet { get; private set; }
 
@@ -13,6 +14,7 @@ public partial class PlanetVisual : Node2D
     {
         _sprite = GetNode<Sprite2D>("Sprite2D");
         _collisionShape = GetNode<CollisionShape2D>("CollisionShape2D");
+        _orbitTrail = GetNodeOrNull<OrbitTrail>("OrbitTrail");
     }
 
     public void Bind(Planet planet)
@@ -32,5 +34,7 @@ public partial class PlanetVisual : Node2D
         Scale = new Vector2(scaleFactor, scaleFactor);
 
         Modulate = BoundPlanet.PlanetColor;
+
+        _orbitTrail?.RecordPosition(GlobalPosition);
     }
 }


### PR DESCRIPTION
Adds Line2D-based orbit trails with gradient fade, world-space rendering, and configurable point limits.

## Changes
- **OrbitTrail.cs** — New `Line2D` script with `[Export]` `MaxPoints` (100) and `MinDistance` (2.0f). Uses `TopLevel = true` for world-space rendering and gradient from transparent tail to visible head.
- **PlanetScene.tscn** — Added OrbitTrail child node under PlanetVisual.
- **PlanetVisual.cs** — Records trail position in `UpdateVisuals()` via `_orbitTrail?.RecordPosition(GlobalPosition)`.

## Design Decisions
- **Line2D over GPUParticles2D** — crisp vector trails, cheaper on mobile
- **TopLevel = true** — renders in world space, not relative to moving parent
- **MinDistance threshold** — prevents redundant point recording
- **MaxPoints cap** — prevents unbounded memory growth

Warning: PlanetVisual.cs is also modified in #70 (PlanetSyncManager) — minor merge conflict expected (3 lines added here).

Closes #71

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>