### PR TITLE
[2.3] Sync planet visual position/scale to physics data

### DIFF
--- a/Scripts/Visual/PlanetSyncManager.cs
+++ b/Scripts/Visual/PlanetSyncManager.cs
@@ -1,0 +1,47 @@
+using Godot;
+using System.Collections.Generic;
+using GravityStellar.Visual;
+
+public partial class PlanetSyncManager : Node
+{
+    private PackedScene _planetScene;
+    private SimulationManager _simulationManager;
+    private readonly Dictionary<string, PlanetVisual> _visuals = new();
+
+    public override void _Ready()
+    {
+        _planetScene = GD.Load<PackedScene>("res://Scenes/PlanetScene.tscn");
+        _simulationManager = GetNode<SimulationManager>("/root/SimulationManager");
+
+        _simulationManager.BodyAdded += OnBodyAdded;
+        _simulationManager.BodyRemoved += OnBodyRemoved;
+    }
+
+    private void OnBodyAdded(string bodyId)
+    {
+        var body = _simulationManager.Registry.GetById(bodyId);
+        if (body is not Planet planet) return;
+
+        var visual = _planetScene.Instantiate<PlanetVisual>();
+        AddChild(visual);
+        visual.Bind(planet);
+        _visuals[bodyId] = visual;
+    }
+
+    private void OnBodyRemoved(string bodyId)
+    {
+        if (_visuals.TryGetValue(bodyId, out var visual))
+        {
+            visual.QueueFree();
+            _visuals.Remove(bodyId);
+        }
+    }
+
+    public override void _Process(double delta)
+    {
+        foreach (var visual in _visuals.Values)
+        {
+            visual.UpdateVisuals();
+        }
+    }
+}


### PR DESCRIPTION
Implements PlanetSyncManager that bridges physics data to Godot visuals.

## What
- Creates PlanetSyncManager at Scripts/Visual/PlanetSyncManager.cs
- Listens to SimulationManager.BodyAdded/BodyRemoved signals
- Spawns/despawns PlanetVisual nodes for Planet-type bodies only
- Updates all visual positions, scales, and colors every render frame via _Process()
- Dictionary for O(1) lookup by body ID

## Why
Bridges the gap between physics simulation (data objects) and the Godot scene tree (visuals). Decoupled via signals.

Closes #70

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>